### PR TITLE
fix: sg without udp/tcp rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ module "test-cluster" {
 
     cluster = {
         bastion = {
-            net_prefix = "10.110.1"             # only /24 networks are supported at the moment
+            network = "10.110.1.0/24"             
             flavor_name = "C1R2"
             volume_size = 20
             # volume_type = "io-nvme"           # optional volume type
@@ -25,7 +25,7 @@ module "test-cluster" {
             # open_udp_ports_for = ...
         }
         nginx = {
-            net_prefix = "10.110.2"
+            network = "10.110.2.0/24"
             flavor_name = "C2R4"
             image_name = "Centos-8-2004"
             volume_size = 20
@@ -38,7 +38,7 @@ module "test-cluster" {
             }
         }
         application = {
-            net_prefix = "10.110.3"
+            network = "10.110.3.0/24"
             flavor_name = "C4R8"
             image_name = "Centos-8-2004"
             volume_size = 20
@@ -49,7 +49,7 @@ module "test-cluster" {
             }
         }
         mongo = {
-            net_prefix = "10.110.4"
+            network = "10.110.4.0/24"
             flavor_name = "C4R8"
             image_name = "Centos-8-2004"
             volume_size = 20
@@ -73,7 +73,7 @@ module "test-cluster" {
 * `dns_servers` - a list of dns servers
 * `key_pair` - name of public key uploaded to openstack
 * `cluster` - a "map" with named groups, where each group contains the following fields:
-  * `net_prefix` - 3-octets of the network for this group (eg. "10.110.1")
+  * `network` -  network for this group (eg. "10.110.1.0/24")
   * `flavor_name` - flavor name for instances in this group (eg. "C1R2")
   * `volume_size` - size of bootable volumes created for each instance in this group
   * `image_name` - base image name for volumes in this group (eg. "Centos-8-2004")
@@ -88,7 +88,7 @@ module "test-cluster" {
 
 ## Resources
 The module creates a new *openstack_networking_router_v2* connected to the external network and then, for each subelement of `cluster`, the following set of resources:
-   * a *openstack_networking_network_v2*, a *openstack_networking_subnet_v2* and a *openstack_networking_router_interface_v2* for the subnetwork (based on `net_prefix`)
+   * a *openstack_networking_network_v2*, a *openstack_networking_subnet_v2* and a *openstack_networking_router_interface_v2* for the subnetwork (based on `network`)
    * an *openstack_networking_secgroup_v2* with:
      * **allow-all-out** rules for TCP/UDP/ICMP
      * an optional set of **allow-in-tcp** rules based on `open_tcp_ports_for`
@@ -126,7 +126,7 @@ open_tcp_ports_for = {
 ```
 * each key represents a remote_ip, which can be:
   * a CIDR (eg. "0.0.0.0/0") or 
-  * the name of a group from `cluster` definition - in such case it will turn into `${net_prefix}.0/24`
+  * the name of a group from `cluster` definition - in such case it will turn into `${network}`
 * each value is an array of ports to be opened. Array elements can be port numbers or port ranges (strings with a dash, eg "10000-20000")
 
 ## Fixed IPs and Floating IPs

--- a/cluster/full.tf
+++ b/cluster/full.tf
@@ -4,15 +4,15 @@ module "net" {
     environment = var.environment
     dns_servers = var.dns_servers
 
-    networks = { for name, config in var.cluster: name => config.net_prefix } 
+    networks = { for name, config in var.cluster: name => config.network } 
     network_rules = { 
         for name, config in var.cluster: name => {
             in_tcp = can(config.open_tcp_ports_for) ? {
                 for source, ports in config.open_tcp_ports_for: source => ports
-            } : null
+            } : {}
             in_udp = can(config.open_udp_ports_for) ? {
                 for source, ports in config.open_udp_ports_for: source => ports 
-            } : null
+            } : {}
         }
     }
 }

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -16,7 +16,7 @@ variable "dns_servers" {
 variable "cluster" {
     #   The type should be declared as:
     #     map(object({
-    #        net_prefix = string
+    #        network = string
     #        count = optional(number)
     #        flavor_name = string
     #        image_name = optional(string)

--- a/environment-test.tf
+++ b/environment-test.tf
@@ -7,7 +7,7 @@ module "test-cluster" {
 
     cluster = {
         bastion = {
-            net_prefix = "10.110.1"             # only /24 networks are supported at the moment
+            network = "10.110.1.0/24"             
             flavor_name = "C1R2"
             volume_size = 20
             # volume_type = "io-nvme"           # optional volume type
@@ -21,7 +21,7 @@ module "test-cluster" {
             # open_udp_ports_for = ...
         }
         nginx = {
-            net_prefix = "10.110.2"
+            network = "10.110.2.0/24"
             flavor_name = "C2R4"
             image_name = "Centos-8-2004"
             volume_size = 20
@@ -34,7 +34,7 @@ module "test-cluster" {
             }
         }
         application = {
-            net_prefix = "10.110.3"
+            network = "10.110.3.0/24"
             flavor_name = "C4R8"
             image_name = "Centos-8-2004"
             volume_size = 20
@@ -45,7 +45,7 @@ module "test-cluster" {
             }
         }
         mongo = {
-            net_prefix = "10.110.4"
+            network = "10.110.4.0/24"
             flavor_name = "C4R8"
             image_name = "Centos-8-2004"
             volume_size = 20

--- a/network/network.tf
+++ b/network/network.tf
@@ -10,7 +10,7 @@ resource "openstack_networking_network_v2" "net" {
 }
 
 locals {
-    cidr_by_names = { for key, value in var.networks : key => "${value}.0/24" }
+    cidr_by_names = var.networks
 }
 
 resource "openstack_networking_subnet_v2" "subnets" {

--- a/network/security_groups.tf
+++ b/network/security_groups.tf
@@ -2,21 +2,7 @@ locals {
     # https://www.terraform.io/docs/language/functions/flatten.html
     tcp_rules = flatten([
         for network_key, network_rules in var.network_rules: [
-            for remoteip, ports in network_rules.in_tcp: [
-                for port in ports: {
-                    network_key = network_key
-                    remote_ip_prefix = try(local.cidr_by_names[remoteip], remoteip)
-                    # https://stackoverflow.com/questions/47243474/how-to-check-if-string-contains-a-substring-in-terraform-interpolation
-                    port_min = replace(tostring(port), "-", "") != tostring(port) ? split("-", tostring(port))[0] : port
-                    port_max = replace(tostring(port), "-", "") != tostring(port) ? split("-", tostring(port))[1] : port
-                }
-            ] if network_rules.in_tcp != null
-        ]
-    ])
-
-    udp_rules = flatten([
-        for network_key, network_rules in var.network_rules: [
-            for remoteip, ports in network_rules.in_udp: [
+            for remoteip, ports in try(network_rules.in_tcp, []): [
                 for port in ports: {
                     network_key = network_key
                     remote_ip_prefix = try(local.cidr_by_names[remoteip], remoteip)
@@ -25,7 +11,21 @@ locals {
                     port_max = replace(tostring(port), "-", "") != tostring(port) ? split("-", tostring(port))[1] : port
                 }
             ]
-        ] if network_rules.in_udp != null
+        ]
+    ])
+
+    udp_rules = flatten([
+        for network_key, network_rules in var.network_rules: [
+            for remoteip, ports in try(network_rules.in_udp, []): [
+                for port in ports: {
+                    network_key = network_key
+                    remote_ip_prefix = try(local.cidr_by_names[remoteip], remoteip)
+                    # https://stackoverflow.com/questions/47243474/how-to-check-if-string-contains-a-substring-in-terraform-interpolation
+                    port_min = replace(tostring(port), "-", "") != tostring(port) ? split("-", tostring(port))[0] : port
+                    port_max = replace(tostring(port), "-", "") != tostring(port) ? split("-", tostring(port))[1] : port
+                }
+            ]
+        ]
     ])
 }
 

--- a/network/variables.tf
+++ b/network/variables.tf
@@ -29,7 +29,7 @@ variable "network_rules" {
 #   So unfortunately, to make it work, type checking is turned off with map(any)
     type = map(any)
     description = "Security group and rules"
-    default = { }
+    default = {}
 }
 
 # 

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "open_stack_password" {
 }
 
 variable "dns_list" { 
-  type = string
+  type = list(string)
   description = "List of DNS addresses"
   default = []
 }


### PR DESCRIPTION
fix for:
`Error: Missing map element

  on .terraform/modules/test-net/network/security_groups.tf line 5, in locals:
   5:             for remoteip, ports in network_rules.in_tcp: [

This map does not have an element with the key "in_tcp".`
